### PR TITLE
针对微信公众号格式重新排版的功能

### DIFF
--- a/app/assets/stylesheets/wechat.scss
+++ b/app/assets/stylesheets/wechat.scss
@@ -1,0 +1,239 @@
+/*
+ *= require highlight
+ */
+
+
+
+/*
+ * NOTE:
+ * - The use of browser-specific styles (-moz-, -webkit-) should be avoided.
+ *   If used, they may not render correctly for people reading the email in
+ *   a different browser than the one from which the email was sent.
+ * - The use of state-dependent styles (like a:hover) don't work because they
+ *   don't match at the time the styles are made explicit. (In email, styles
+ *   must be explicitly applied to all elements -- stylesheets get stripped.)
+ */
+
+/* This is the overall wrapper, it should be treated as the `body` section. */
+body {
+  font-size: 14px;
+}
+
+/* To add site specific rules, you can use the `data-md-url` attribute that we
+   add to the wrapper element. Note that rules like this are used depending
+   on the URL you're *sending* from, not the URL where the recipient views it.
+*/
+/* .markdown-here-wrapper[data-md-url*="mail.yahoo."] ul { color: red; } */
+
+pre, code {
+  font-size: 10px;
+  font-family: Consolas, Inconsolata, Courier, monospace;
+}
+
+code {
+  margin: 0 0.15em;
+  padding: 0 0.3em;
+  white-space: pre-wrap;
+  border: 1px solid #EAEAEA;
+  background-color: #F8F8F8;
+  border-radius: 3px;
+  display: inline; /* added to fix Yahoo block display of inline code */
+}
+
+pre {
+  font-size: 14px;
+  line-height: 1.2em;
+}
+
+pre code {
+  white-space: pre;
+  overflow: auto; /* fixes issue #70: Firefox/Thunderbird: Code blocks with horizontal scroll would have bad background colour */
+  border-radius: 3px;
+  border: 1px solid #CCC;
+  padding: 0.5em 0.7em;
+  display: block !important; /* added to counteract the Yahoo-specific `code` rule; without this, code blocks in Blogger are broken */
+}
+
+pre.highlight code .c {
+  display: block;
+  margin-top: 10px;
+}
+
+/* In edit mode, Wordpress uses a `* { font: ...;} rule+style that makes highlighted
+code look non-monospace. This rule will override it. */
+.markdown-here-wrapper[data-md-url*="wordpress."] code span {
+  font: inherit;
+}
+
+/* Wordpress adds a grey background to `pre` elements that doesn't go well with
+our syntax highlighting. */
+.markdown-here-wrapper[data-md-url*="wordpress."] pre {
+  background-color: transparent;
+}
+
+/* This spacing has been tweaked to closely match Gmail+Chrome "paragraph" (two line breaks) spacing.
+Note that we only use a top margin and not a bottom margin -- this prevents the
+"blank line" look at the top of the email (issue #243).
+*/
+p {
+  /* !important is needed here because Hotmail/Outlook.com uses !important to
+     kill the margin in <p>. We need this to win. */
+  margin: 0 0 20px 0;
+}
+
+table, pre, dl, blockquote, q, ul, ol {
+  margin: 1.2em 0;
+}
+
+ul, ol {
+  padding-left: 2em;
+}
+
+li {
+  margin: 0.5em 0;
+  font-size: 14px;
+}
+
+/* Space paragraphs in a list the same as the list itself. */
+li p {
+  /* Needs !important to override rule above. */
+  margin: 0.5em 0 !important;
+}
+
+/* Smaller spacing for sub-lists */
+ul ul, ul ol, ol ul, ol ol {
+  margin: 0;
+  padding-left: 1em;
+}
+
+/* Use Roman numerals for sub-ordered-lists. (Like Github.) */
+ol ol, ul ol {
+  list-style-type: lower-roman;
+}
+
+/* Use letters for sub-sub-ordered lists. (Like Github.) */
+ul ul ol, ul ol ol, ol ul ol, ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+dl {
+  padding: 0;
+}
+
+dl dt {
+  font-size: 14px;
+  font-weight: bold;
+  font-style: italic;
+}
+
+dl dd {
+  margin: 0 0 1em;
+  padding: 0 1em;
+}
+
+blockquote, q {
+  border-left: 4px solid #DDD;
+  padding: 0 1em;
+  color: #777;
+  quotes: none;
+}
+
+blockquote::before, blockquote::after, q::before, q::after {
+  content: none;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 20px 0 20px;
+  padding: 0;
+  font-weight: bold;
+  color: blue;
+}
+
+h1 {
+  font-size: 18px;
+  border-bottom: 1px solid #ddd;
+  color: blue;
+}
+
+h2 {
+  font-size: 18px;
+  border-bottom: 1px solid #eee;
+}
+
+h3 {
+  font-size: 18px;
+  color: orange;
+}
+
+h4 {
+  font-size: 16px;
+}
+
+h5 {
+  font-size: 16px;
+}
+
+h6 {
+  font-size: 1em;
+  color: #777;
+}
+
+table {
+  padding: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 14px;
+  font: inherit;
+  border: 0;
+}
+
+tbody {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+table tr {
+  border: 0;
+  border-top: 1px solid #CCC;
+  background-color: white;
+  margin: 0;
+  padding: 0;
+}
+
+table tr:nth-child(2n) {
+  background-color: #F8F8F8;
+}
+
+table tr th, table tr td {
+  font-size: 14px;
+  border: 1px solid #CCC;
+  margin: 0;
+  padding: 0.5em 1em;
+}
+
+table tr th {
+  font-weight: bold;
+  background-color: #F0F0F0;
+}
+
+
+/*Syntax Highlighting CSS*/
+
+/*
+
+Zenburn style from voldmar.ru (c) Vladimir Epifanov <voldmar@voldmar.ru>
+based on dark.css by Ivan Sagalaev
+
+*/
+
+.highlight {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #3f3f3f;
+  /*color: #dcdcdc;*/
+  -webkit-text-size-adjust: none;
+}
+
+

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -107,6 +107,14 @@ class TopicsController < ApplicationController
     set_special_node_active_menu
   end
 
+  def show_wechat
+    @topic = Topic.unscoped.includes(:user).find(params[:id])
+    render_404 if @topic.deleted?
+
+    @node = @topic.node
+    render template: "topics/show_wechat", handler: [:erb], layout: 'wechat'
+  end
+
   def new
     @topic = Topic.new(user_id: current_user.id)
     unless params[:node].blank?

--- a/app/views/layouts/wechat.html.erb
+++ b/app/views/layouts/wechat.html.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <%= stylesheet_link_tag "wechat" %>
+  <%= yield :scripts %>
+</head>
+<body>
+  <%= yield %>
+</body>
+</html>

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -48,5 +48,8 @@
     <%= f.submit t("common.save"), class: "btn btn-primary col-xs-2", 'data-disable-with' => t("common.saving"), 'data-tb' => "save-topic" %>
 
     <div class="pull-right hide-ios"><a href="/markdown" target="_blank"><i class="fa fa-tip"></i> 排版说明</a></div>
+    <% if admin? %>
+      <div class="pull-right hide-ios"><a href="show_wechat"><i class="fa fa-tip"></i>微信公众号渲染版</a></div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/topics/show_wechat.html.erb
+++ b/app/views/topics/show_wechat.html.erb
@@ -1,0 +1,2 @@
+<%= @topic.body_html %>
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,6 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w(app.js front.css turbolinks-app.css admin.css)
+Rails.application.config.assets.precompile += %w(app.js front.css turbolinks-app.css admin.css wechat.css)
 
 Rails.application.config.assets.quiet = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
       delete :unfollow
       get :ban
       post :action
+      get :show_wechat
     end
     collection do
       get :no_reply


### PR DESCRIPTION
添加针对微信公众号重新排版的功能，减少每次公众号排版的重复劳动。

使用方式：
1. 使用管理员账号登录
2. 打开想要发布到微信公众号的 topic 的编辑页面，在右下角点击 “微信公众号排版”
3. 拷贝整个 html 的内容到微信公众号编辑器

排版格式已针对公众号进行调整，也已修复代码块中换行符会被忽略的问题，拷贝完毕后一般只需要进行微调即可。

原理：
微信公众号文章的 html 本身有一个默认样式，若采用网页部分内容复制粘贴的形式，会由于部分 css 丢失导致套用了微信的默认样式。
微信默认样式和浏览器（如 chrome）默认样式差异较大，且只会在手机预览的时候生效，因此在 chrome 浏览器预览一切正常的页面，到了手机上就会各种乱套。常见的是 li 标签的字号自动变成了 16px ，明显比其他文字大。
解决方法是新建一个 html 文件，内容完全就是需要粘贴到公众号的内容，内置针对微信默认样式编写的 css 文件，确保需要覆盖微信默认样式的部分都有覆盖。

具体方法：
1. 新建一个 layout 文件，专门用于单独的微信排版用的 html 文件
2. 新建一个 show_wechat 的界面模块，里面直接显示 topic 的 html 内容
3. 新建一个针对微信公众号的 css 样式，放在微信排版专用的 html 文件中
4. 在 topic 编辑页面新增了一个入口，点击后打开的页面会使用上面的三个文件进行渲染，并通过调试确保渲染结果基本在复制粘贴到微信编辑器后不会乱。