### PR TITLE
完成 微信公众号排版增强 #49 :

### DIFF
--- a/app/assets/stylesheets/wechat.scss
+++ b/app/assets/stylesheets/wechat.scss
@@ -217,6 +217,11 @@ table tr th {
   background-color: #F0F0F0;
 }
 
+// 超链接粘贴后都会失效，干脆去掉蓝色底和下划线，让它长得不像超链接
+a {
+  color: black;
+  text-decoration: none;
+}
 
 /*Syntax Highlighting CSS*/
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -21,6 +21,8 @@ class Setting < RailsSettings::Base
     topic_list_top_html
     after_topic_html
     before_topic_html
+    before_wechat_html
+    after_wechat_html
     node_ids_hide_in_topics_index
     reject_newbie_reply_in_the_evening
     newbie_limit_time

--- a/app/views/topics/_buttons.html.erb
+++ b/app/views/topics/_buttons.html.erb
@@ -29,10 +29,11 @@
       <% end %>
     <% end %>
     <%= link_to "", edit_topic_path(@topic), class: "fa fa-pencil", title: "修改本帖" %>
-      <% if can?(:destroy, @topic) %>
+    <% if can?(:destroy, @topic) %>
       <%= link_to "", topic_path(@topic.id), method: :delete, remote: true, 'data-confirm': t("common.confirm_delete"), class: "fa fa-trash", title: "删除本帖" %>
       <% end %>
     <% end %>
+    <%= link_to "", show_wechat_topic_path(@topic), class: "fa fa-weixin", target: "_blank", title: "微信排版" %>
     <% if admin? %>
       <%= link_to "", new_ad_path(topic_id: @topic.id), class: "fa fa-space-shuttle", title: "推送本帖到客户端头条" %>
     <% end %>

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -48,8 +48,6 @@
     <%= f.submit t("common.save"), class: "btn btn-primary col-xs-2", 'data-disable-with' => t("common.saving"), 'data-tb' => "save-topic" %>
 
     <div class="pull-right hide-ios"><a href="/markdown" target="_blank"><i class="fa fa-tip"></i> 排版说明</a></div>
-    <% if admin? %>
-      <div class="pull-right hide-ios"><a href="show_wechat"><i class="fa fa-tip"></i>微信公众号渲染版</a></div>
-    <% end %>
+
   </div>
 <% end %>

--- a/app/views/topics/show_wechat.html.erb
+++ b/app/views/topics/show_wechat.html.erb
@@ -1,2 +1,6 @@
+<%= raw Setting.before_wechat_html %>
+
 <%= @topic.body_html %>
+
+<%= raw Setting.after_wechat_html %>
 

--- a/config/locales/menu.en.yml
+++ b/config/locales/menu.en.yml
@@ -106,6 +106,9 @@
     recent_topics_title: "%{name} Forum"
     recent_node_topics_description: "Recent Topic in %{node_name} of %{name} Forum."
     recent_node_topics_title: "%{node_name} node of %{name} Forum"
+  setting:
+    before_wechat_html: "HTML codes before wechat content. Also can be used for modify css"
+    after_wechat_html: "HTML codes after wechat content."
   pagination:
     next: "Next &#8594;"
     prev: "&#8592; Prev"

--- a/config/locales/menu.zh-CN.yml
+++ b/config/locales/menu.zh-CN.yml
@@ -123,6 +123,8 @@
     topic_list_top_html: "话题列表首页头上 HTML"
     before_topic_html: "话题正文前面的 HTML"
     after_topic_html: "话题后面的 HTML"
+    before_wechat_html: "微信排版正文前面的 HTML ，也可用来做 css 微调"
+    after_wechat_html: "微信排版正文后面的 HTML"
     footer_html: "页脚 HTML"
     wiki_index_html: "WIKI 首页 HTML"
     wiki_sidebar_html: "WIKI 边栏 HTML"

--- a/config/locales/menu.zh-TW.yml
+++ b/config/locales/menu.zh-TW.yml
@@ -123,6 +123,8 @@
     topic_list_top_html: "話題列表首頁头上 HTML"
     before_topic_html: "話題正文前面的 HTML"
     after_topic_html: "話題後面的 HTML"
+    before_wechat_html: "微信排版正文前面的 HTML ，也可用来做 css 微调"
+    after_wechat_html: "微信排版正文後面的 HTML"
     footer_html: "頁腳 HTML"
     wiki_index_html: "WIKI 首頁 HTMl"
     index_html: "網站首頁 HTML"


### PR DESCRIPTION
1. 排版入口移到帖子底部编辑按钮旁边
2. 排版入口权限改为管理员及作者可看到
3. 管理员后台添加微信排版正文前及正文后 html 内容的设置项

详情可查看 <https://github.com/testerhome/homeland/issues/49>