### PR TITLE
fix: 通过隐藏部分控件，修复在宽度为 768px 至 992px 的屏幕上，导航栏出现2行的问题。

### DIFF
--- a/app/views/shared/_usernav.html.erb
+++ b/app/views/shared/_usernav.html.erb
@@ -39,7 +39,7 @@
 </ul>
 
 <ul class="nav navbar-nav user-bar navbar-right">
-  <li class="nav-search hidden-xs hidden-sm">
+  <li class="nav-search hidden-xs hidden-sm hidden-md">
     <form class="navbar-form form-search active" action="/search" method="GET">
       <div class="form-group">
         <input class="form-control" name="q" type="text" value="<%= params[:q] %>" placeholder="搜索本站内容" />
@@ -56,7 +56,7 @@
     <a href="<%= main_app.notifications_path %>" class="<%= badge_class %>" title="通知"><i class="fa fa-bell"></i><span class="count"><%= unread_notify_count %></span></a>
   </li>
   <% if not current_user.newbie? %>
-    <li>
+    <li class="hidden-sm">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
         <i class="fa fa-plus"></i> <span class="caret"></span>
       </a>


### PR DESCRIPTION
经过比较，ruby-china 不会有类似问题。问题的根源在于我们的导航栏比 ruby-china 内容多，所以无法适应 bootstrap 默认在 小屏幕平板 (≥768px) 、中等屏幕桌面 (≥992px) 上给出的固定宽度（分别是 750px、970px），挤成了2行。

解决方法有两个：
1. 减少控件数量，避免挤成2行。
2. 通过自定义的 css 在导航栏处覆盖 bootstrap 默认指定的宽度，让它足够宽。

采用第二种方案，弊端是违背了 bootstrap 对屏幕的判断，导致其默认的 css 隐藏样式失效，以后导航栏调整后，适配起来更麻烦。

所以使用第一种方案。小屏幕平板 (≥768px) 时增加隐藏发帖按钮，中等屏幕桌面 (≥992px) 增加隐藏搜索栏。