### PR TITLE
fix: 上一个修复在 768-992 宽度时还是会变成两行，所以在这个宽度时隐藏通知信息，让它变成一行。

### DIFF
--- a/app/views/shared/_usernav.html.erb
+++ b/app/views/shared/_usernav.html.erb
@@ -52,7 +52,7 @@
   badge_class = ""
   badge_class = "new" if unread_notify_count > 0
   %>
-  <li class="notification-count">
+  <li class="notification-count hidden-sm">
     <a href="<%= main_app.notifications_path %>" class="<%= badge_class %>" title="通知"><i class="fa fa-bell"></i><span class="count"><%= unread_notify_count %></span></a>
   </li>
   <% if not current_user.newbie? %>


### PR DESCRIPTION
之前测试时，本地导航栏内容和线上有些出入，导致上线后在宽度为 768-992 px 时还是会有两行（通知图标被挤下去了）

经过测试，在这个宽度范围内隐藏通知图标，可以修复此问题。所以再次提交 pr 。