### PR TITLE
修复专栏文章列表页当页数大于有内容的最大页数时，即使不是专栏主人，也会出现 写专栏 入口的问题

### DIFF
--- a/app/views/columns/show.html.erb
+++ b/app/views/columns/show.html.erb
@@ -32,14 +32,16 @@
     <% else %>
         <div class="panel-heading node-header">
           <ul class="filter nav nav-pills">
-            暂时没有文章
+            暂时没有文章或页数已超过最后一页
           </ul>
         </div>
-        <div class="column">
-          <div class="bs-dropzone">
-            <%= link_to " 写文章", new_column_article_path(@column.id), class: "fa fa-pencil", title: "编辑发布" %>
+        <% if current_user == @column.user %>
+          <div class="column">
+            <div class="bs-dropzone">
+              <%= link_to " 写文章", new_column_article_path(@column.id), class: "fa fa-pencil", title: "编辑发布" %>
+            </div>
           </div>
-        </div>
+        <% end %>
     <%end%>
       </div>
 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2800797/48492273-642f5f80-e864-11e8-8d2f-77a7c62c496b.png)

![image](https://user-images.githubusercontent.com/2800797/48492299-714c4e80-e864-11e8-94ec-fbfc8ad08e0b.png)
