### PR TITLE
fix: 尝试修复个人通知中 topic 为 nil 时直接服务器异常的问题

### DIFF
--- a/app/views/notifications/mentions/_reply.html.erb
+++ b/app/views/notifications/mentions/_reply.html.erb
@@ -4,10 +4,10 @@
 %>
 <div class="media-heading">
   <span class="info">在
-      <%= topic.isArticle? ? article_title_tag(topic) : topic_title_tag(topic) %>
+      <%= topic&.isArticle? ? article_title_tag(topic) : topic_title_tag(topic) %>
     提及你：</span>
 </div>
-<% if reply.present? %>
+<% if reply&.present? %>
   <div class="media-content summary markdown">
     <%= reply.body_html %>
   </div>


### PR DESCRIPTION
我的账号在查看个人通知时，会返回服务器 500 错误，对应异常：

```
#<ActionView::Template::Error: undefined method `isArticle?' for nil:NilClass>


--------------------------------------------------
Method:     GET
URL:        http://testerhome.com/notifications/personal
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
Language:   zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7
Server:     104bbc56cedc
Process:    13
--------------------------------------------------


/var/www/homeland/app/views/notifications/mentions/_reply.html.erb:7:in `_app_views_notifications_mentions__reply_html_erb___3249961878684007281_70351599555460'
/var/www/homeland/vendor/bundle/ruby/2.4.0/gems/actionview-5.2.0.rc1/lib/action_view/template.rb:159:in `block in render'
```

由于异常是由 nil 引起，因此调整了下，`topic.article?` 改为 `topic&article?` ，等价于 `topic != nill && topic.article?` ，增加判空判断。

PS：因为本地怎么删数据都无法重现此问题，所以只能说是尝试修复。