### PR TITLE
fix: 修复当被举报信息作者被删除时，会导致举报编辑页面无法打开的问题

### DIFF
--- a/app/views/admin/tip_offs/_form.html.erb
+++ b/app/views/admin/tip_offs/_form.html.erb
@@ -18,8 +18,7 @@
     <dd class="col-sm-9"><a href="<%= @tipOff[:content_url] %>" target="_blank"><%=@tipOff[:content_url]%></a></dd>
 
     <dt class="col-sm-3"><%=t("tip_off.content_author")%></dt>
-    <dd class="col-sm-9"><%= link_to User.find(@tipOff[:content_author_id])[:name], User.find(@tipOff[:content_author_id]), target: "_blank" %></dd>
-
+    <dd class="col-sm-9"><%=user_name_tag @tipOff.content_author %></dd>
     <dt class="col-sm-3"><%=t("tip_off.description")%></dt>
     <dd class="col-sm-9"><%= @tipOff[:body] %></dd>
 


### PR DESCRIPTION
线上有部分举报信息，被举报用户会已被硬删除（连 id 都找不到），导致举报详情页打不开，举报一直挂在那里无法处理。

看着不爽，把它 fix 掉。