### PR TITLE
feat: 帖子和用户主页下的团队展示界面，除了展示图标，加上展示团队名称

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -228,6 +228,12 @@ table.node-topics {
   .user-teams-avatar {
     padding: 10px;
   }
+  .user-team-name {
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis;
+    width: 100%;
+  }
 }
 
 .user-card {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -222,6 +222,7 @@ table.node-topics {
   }
 
   .user-teams {
+    padding: 12px 0px;
     .media-object { display: inline-block; margin:4px 2px; }
   }
   .user-teams-avatar {

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -100,7 +100,7 @@ module UsersHelper
     html_options[:title] = team.fullname
     html_options[:style] = 'text-decoration: none'
 
-    template = "<p style='text-decoration: none;'> #{img} #{team.name} </p>"
+    template = "<div class='user-team-name'> #{img} #{team.name} </div>"
     if link
       link_to(raw(template), "/#{team.login}", html_options)
     else

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -79,7 +79,34 @@ module UsersHelper
       raw img
     end
   end
-  alias team_avatar_tag user_avatar_tag
+
+  def team_avatar_tag(team, version = :md, link: true, timestamp: nil)
+    # 不仅显示团队图标，也显示团队名称
+    width     = user_avatar_width_for_size(version)
+    img_class = "media-object avatar-#{width}"
+
+    img =
+        if team.blank?
+          image_tag("avatar/#{version}.png", class: img_class)
+        elsif team.avatar?
+          image_url = team.avatar.url(version)
+          image_url += "?t=#{team.updated_at.to_i}" if timestamp
+          image_tag(image_url, class: img_class)
+        else
+          image_tag(team.letter_avatar_url(width * 2), class: img_class)
+        end
+
+    html_options = {}
+    html_options[:title] = team.fullname
+    html_options[:style] = 'text-decoration: none'
+
+    template = "<p style='text-decoration: none;'> #{img} #{team.name} </p>"
+    if link
+      link_to(raw(template), "/#{team.login}", html_options)
+    else
+      raw template
+    end
+  end
 
   def render_user_level_tag(user)
     return "" if user.blank?

--- a/app/views/topics/_topic_author_info.html.erb
+++ b/app/views/topics/_topic_author_info.html.erb
@@ -21,13 +21,12 @@
         <% end %>
       </div>
 
-
       <% if Setting.has_module?(:team) %>
           <% if !@topic.user.teams.blank? %>
               <div class="user-teams">
                 <div>
                   <% @topic.user.valid_teams.each do |team| %>
-                      <%= user_avatar_tag(team, :sm) %>
+                      <%= team_avatar_tag(team, :sm) %>
                   <% end %>
                 </div>
               </div>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -118,7 +118,7 @@
           <div class="panel user-teams">
             <div class="panel-body user-teams-avatar">
               <% @user.valid_teams.each do |team| %>
-                  <%= user_avatar_tag(team, :md) %>
+                  <%= team_avatar_tag(team, :md) %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
关联 issue ：https://github.com/testerhome/homeland/issues/98

效果图：
用户主页
![image](https://user-images.githubusercontent.com/2800797/63360685-61d4d580-c3a1-11e9-80e4-fcdb818b78cd.png)
帖子作者栏
![image](https://user-images.githubusercontent.com/2800797/63360705-6ef1c480-c3a1-11e9-93a0-93548fdd244e.png)
