### PR TITLE
fix: 站点首页的最新开源项目，过滤条件改为和开源项目板块的一致（主要是去掉未审核通过的项目）

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,7 +12,7 @@ class HomeController < ApplicationController
       @open_bugs = bugs_node.topics.withoutDraft.open.limit(5).to_a
     end
     if Setting.has_module?(:opensource_project)
-      @opensource_projects = OpensourceProject.latest.limit(5).to_a
+      @opensource_projects = OpensourceProject.includes(:user).published.latest.limit(5).to_a
     end
   end
 


### PR DESCRIPTION
目前站点首页的最新开源项目部分，把未审核通过的也一并显示了，和开源项目板块有出入。
此次调整改为和开源项目板块一致。