### PR TITLE
解决举报文章消息带有 access_token 导致切换用户问题+专栏文章默认不推送社区

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -46,7 +46,8 @@ class ArticlesController < TopicsController
     if !column.active
       redirect_to(columns_user_path(current_user), notice: "专栏被屏蔽！")
     end
-    @article = Article.new(user_id: current_user.id, column_id: params[:column_id])
+    # 默认不推送到社区，减少刷屏和骚扰
+    @article = Article.new(user_id: current_user.id, column_id: params[:column_id], article_public:false)
   end
 
   def create

--- a/app/controllers/tip_offs_controller.rb
+++ b/app/controllers/tip_offs_controller.rb
@@ -15,6 +15,13 @@ class TipOffsController < ApplicationController
     @tipOff = TipOff.new(tip_off_params)
     @tipOff.reporter_id = current_user.id
     @tipOff.create_time = Time.now
+
+    # 移动客户端上举报，内容 url 会带上 access_token 参数导致可以切换用户。要把它去掉
+    if '?access_token'.in? @tipOff.content_url
+      end_position = @tipOff.content_url =~ /\?access_token/
+      @tipOff.content_url = @tipOff.content_url[0..end_position-1]
+    end
+
     if @tipOff.save
       # 给管理员群发通知
       admin_users = User.admin_users


### PR DESCRIPTION
ce9160a3 feat: 专栏文章默认不推送到社区首页，减少骚扰
820943c3 fix: 修复移动客户端举报时，举报地址带有 access_token 会导致管理员点击后切换问题
