### PR TITLE
fix bugs

### DIFF
--- a/app/controllers/column_channels_controller.rb
+++ b/app/controllers/column_channels_controller.rb
@@ -5,7 +5,7 @@ class ColumnChannelsController < TopicsController
     @simple_columns = Setting.column_channel_simple_column_ids.map {|id| Column.find_by_id(id) }.reject(&:nil?)
     @public_enterprise_columns = Setting.column_channel_public_enterprise_column_ids.map {|id| Column.find_by_id(id) }.reject(&:nil?)
 
-    @sections = Section.all.reject {|s| ['私密圈子', '测试服务'].include? s.name }
+    @sections = Section.all.select {|s| Setting.column_channels_show_node_names.include? s.name }
 
     if params[:section_id].blank?
       @topics = fetch_public_or_enterprise_topics
@@ -53,6 +53,6 @@ class ColumnChannelsController < TopicsController
     # 55是违规处理区， 61 是 NoPoint
     where.not(node_id: [Setting.article_node, 55, 61]).
 
-    order(Arel.sql("date(topics.created_at) desc"))
+    order(Arel.sql("date(topics.created_at) desc")).limit(1500)
   end
 end

--- a/app/controllers/topics/list_actions.rb
+++ b/app/controllers/topics/list_actions.rb
@@ -11,7 +11,7 @@ module Topics
     # GET /topics/no_reply
     %i[no_reply popular].each do |name|
       define_method(name) do
-        @topics = topics_scope.send(name).last_actived.page(params[:page])
+        @topics = topics_scope.with_filter_public_end_enterprise.send(name).last_actived.page(params[:page])
 
         render_index(name)
       end
@@ -19,7 +19,7 @@ module Topics
 
     # GET /topics/last_reply
     def last_reply
-      @topics = topics_scope.last_reply.page(params[:page])
+      @topics = topics_scope.with_filter_public_end_enterprise.last_reply.page(params[:page])
       render_index("last_reply")
     end
 
@@ -31,7 +31,7 @@ module Topics
 
     # GET /topics/last
     def last
-      @topics = topics_scope.recent.page(params[:page])
+      @topics = topics_scope.with_filter_public_end_enterprise.recent.page(params[:page])
       render_index("recent")
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -106,6 +106,7 @@ class Setting < RailsSettings::Base
     enable_audit_user_update
     audit_user_update_attributes
     search_need_login
+    column_channels_show_node_names
   ]
 
   # = System
@@ -264,6 +265,8 @@ class Setting < RailsSettings::Base
   field :audit_user_update_attributes, type: :array, default: ["name"]
 
   field :search_need_login, type: :boolean, default: true
+
+  field :column_channels_show_node_names, type: :array, default: %w[研发效能 测试技术&方案 测试基础&方法 专题测试 职业发展 社区活动]
 
   # = ReCaptcha
   field :use_recaptcha, default: false, type: :boolean

--- a/app/views/column_channels/index.html.erb
+++ b/app/views/column_channels/index.html.erb
@@ -1,5 +1,5 @@
 
-<div class="row mb-3">
+<div class="mb-3 row">
 <%unless @column_channel_top_ads.blank?%>
   <div class="col-12 ">
     <%= render "top_ad_slide"%>
@@ -27,8 +27,8 @@
       </div>
 
       <% if  @topics.total_pages > 1 %>
-      <div class="card-footer clearfix">
-        <%= paginate @topics %>
+      <div class="clearfix card-footer">
+        <%= paginate @topics,window: 1, outer_window: 2, total_pages: @topics.total_pages >=60 ? 60 : @topics.total_pages  %>
       </div>
       <% end %>
 

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,13 +1,25 @@
+
+
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
 <%= paginator.render do -%>
-  <ul class="pagination">
+  <nav class="pagination" role="navigation" aria-label="pager">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
-      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+      <% if page.display_tag? -%>
         <%= page_tag page %>
       <% elsif !page.was_truncated? -%>
         <%= gap_tag %>
       <% end -%>
     <% end -%>
-    <%= next_page_tag unless current_page.last? %>
-  </ul>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
 <% end -%>

--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -15,7 +15,7 @@
     <div class="<%= class_names.join(' ') %>" data-id="<%= reply.id %>" id="reply<%= floor %>">
       <div id="reply-<%= reply.id %>" data-floor="<%= floor %>">
 
-        <% if reply.audit_status != "approved" %>
+        <% if reply.audit_status != "approved" && !reply.deleted? %>
           <!--能看到这的要么是管理员要么是作者-->
           <div class="reply-audit-status tw-p-2 tw-mb-2 tw-bg-yellow-100">
             回复状态为 <%= audit_chinese_status(reply.audit_status)%> 仅自己<%= current_user.admin? ? "和管理员" : "" %>可见
@@ -106,7 +106,9 @@
   <% else %>
     <div class="<%= class_names.join(' ') %>" data-id="<%= reply.id %>" id="reply<%= floor %>">
       <div id="reply-<%= reply.id %>" data-floor="<%= floor %>">
-      <% if reply.audit_status =='pending' %>
+      <% if reply.deleted?%>
+        <div class="text-center deleted"><%= floor %><%= t("common.floor")%> <%= t("common.has_deleted")%></div> 
+      <% elsif reply.audit_status =='pending' && current_user %>
         
         正在紧张审核中...
       <% else %>


### PR DESCRIPTION
1. 修正评论删除后， 用户仍然还显示 审核信息， 和原信息的问题
修正后： 作者删除评论后， 作者本人不会再看到原信息。

2. 修正当评论 审核失败后， 用户选择 删除评论 ，  其他用户和匿名访问时会显示 审核未通过 不显示
 修正后： 楼层显示为评论已删除

3. 修正在匿名用户状态下， 看到的未通过审核的回复 会显示 正在审核中
修正后： 改为  回复内容未通过审核，暂不显示

4. 修正点击社区 ，有一个最新回复、最新发布的功能，会将非合作用户属性查询出来
修正后: 不会再出现

5. 修正专栏分页导航变形
修正后： 最多 60 页分页， 且分页不会变形

6. 专栏分类，需要只显示部分节点
修正后：   做为可配置    在系统配置的全局设置里  可以设置 column_channels_show_node_names 



